### PR TITLE
Avoid "Invalid opcode 153/1/8" (fixes #16)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-12-05  Todd Christensen <tchristensen at bykd.com>
+
+	* Avoid invalid opcode 153/1/8 by not setting op2 to unused for
+          ZEND_DECLARE_LAMBDA_FUNCTION.
+
 2012-08-16  Hans Rakers <hans at rakers.org>
 
 	* Remove current memory protection implementation. This code has

--- a/optimize.c
+++ b/optimize.c
@@ -2889,7 +2889,14 @@ static int build_cfg(zend_op_array *op_array, BB* bb)
             if ((dsc->ops & OP2_MASK) == OP2_CLASS) {
                 OP2_TYPE(op) = IS_VAR;
             } else if ((dsc->ops & OP2_MASK) == OP2_UNUSED) {
+#ifdef ZEND_DECLARE_LAMBDA_FUNCTION
+                /* The opcode handler expects very specific op types here.  */
+                if (op->opcode != ZEND_DECLARE_LAMBDA_FUNCTION) {
+                    OP2_TYPE(op) = IS_UNUSED;
+                }
+#else
                 OP2_TYPE(op) = IS_UNUSED;
+#endif
             }
 #ifndef ZEND_ENGINE_2_4
             else if ((dsc->ops & OP2_MASK) == OP2_FETCH &&


### PR DESCRIPTION
Only the one case is handled in zend_opcode_handlers, so the op1/op2 types must not be changed.  Although op2 technically is unused.

Although, I'm sure there are other bugs with newer PHP versions.